### PR TITLE
Fixes background of wiki

### DIFF
--- a/seti-imesec.css
+++ b/seti-imesec.css
@@ -7,7 +7,7 @@
 
 */
 
-
+html { background-color: #242424; }
 .cm-s-seti.CodeMirror {
   background-color: #151718 !important;
   color: #CFD2D1 !important;


### PR DESCRIPTION
closes [#1](https://github.com/IMEsec-USP/issues/issues/1)

Before that, we had a white background which didn't match the wiki style. Now we have this:

![image](https://user-images.githubusercontent.com/7110169/76689409-93f3a080-662d-11ea-9032-dee89e20d5d0.png)
